### PR TITLE
chore: updates for consistent naming and re apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 <!-- BEGIN_TF_DOCS -->
 # ALZ Terraform Module
 
-> ⚠️ ***Warning*** ⚠️ This module is still in development but is ready for initial testing and feedback via [GitHub Issues](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/issues).
+> ⚠️ ***Warning*** ⚠️ This module is currently in development and is not yet ready for use. It should be considered experimental and is subject to change.
 
-This repository contains Terraform module for deploying Azure Landing Zones (ALZs).
-Make sure to review the examples.
+This repository contains an early prototype of a new Terraform module for deploying Azure Landing Zones (ALZs).
 
 <!-- markdownlint-disable MD033 -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <!-- BEGIN_TF_DOCS -->
 # ALZ Terraform Module
 
-> ⚠️ ***Warning*** ⚠️ This module is currently in development and is not yet ready for use. It should be considered experimental and is subject to change.
+> ⚠️ ***Warning*** ⚠️ This module is still in development but is ready for initial testing and feedback via [GitHub Issues](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/issues).
 
-This repository contains an early prototype of a new Terraform module for deploying Azure Landing Zones (ALZs).
+- This repository contains Terraform module for deploying Azure Landing Zones (ALZs).
+
+- Make sure to review the examples.
 
 <!-- markdownlint-disable MD033 -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 > ⚠️ ***Warning*** ⚠️ This module is still in development but is ready for initial testing and feedback via [GitHub Issues](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/issues).
 
 - This repository contains Terraform module for deploying Azure Landing Zones (ALZs).
-
 - Make sure to review the examples.
 
 <!-- markdownlint-disable MD033 -->

--- a/_header.md
+++ b/_header.md
@@ -1,5 +1,7 @@
 # ALZ Terraform Module
 
-> ⚠️ ***Warning*** ⚠️ This module is currently in development and is not yet ready for use. It should be considered experimental and is subject to change.
+> ⚠️ ***Warning*** ⚠️ This module is still in development but is ready for initial testing and feedback via [GitHub Issues](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/issues).
 
-This repository contains an early prototype of a new Terraform module for deploying Azure Landing Zones (ALZs).
+- This repository contains Terraform module for deploying Azure Landing Zones (ALZs).
+
+- Make sure to review the examples.

--- a/_header.md
+++ b/_header.md
@@ -3,5 +3,4 @@
 > ⚠️ ***Warning*** ⚠️ This module is still in development but is ready for initial testing and feedback via [GitHub Issues](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/issues).
 
 - This repository contains Terraform module for deploying Azure Landing Zones (ALZs).
-
 - Make sure to review the examples.

--- a/examples/alzreference/README.md
+++ b/examples/alzreference/README.md
@@ -12,16 +12,17 @@ resource "random_pet" "this" {
 
 module "naming" {
   source = "Azure/naming/azurerm"
+  suffix = [ random_pet.this.id ]
 }
 
 module "alz_management_resources" {
   source  = "Azure/alz-management/azurerm"
   version = "~> 0.1.0"
 
-  automation_account_name      = module.naming.automation_account.name_unique
+  automation_account_name      = module.naming.automation_account.name
   location                     = local.default_location
-  log_analytics_workspace_name = module.naming.log_analytics_workspace.name_unique
-  resource_group_name          = module.naming.resource_group.name_unique
+  log_analytics_workspace_name = module.naming.log_analytics_workspace.name
+  resource_group_name          = module.naming.resource_group.name
 }
 
 # This allows us to get the tenant id
@@ -84,8 +85,8 @@ module "alz_archetype_connectivity" {
 
 module "alz_archetype_management" {
   source                             = "../../"
-  id                                 = "management"
-  display_name                       = "management"
+  id                                 = "${random_pet.this.id}-management"
+  display_name                       = "${random_pet.this.id}-management"
   parent_id                          = module.alz_archetype_platform.management_group_name
   base_archetype                     = "management"
   default_location                   = local.default_location

--- a/examples/alzreference/README.md
+++ b/examples/alzreference/README.md
@@ -12,7 +12,7 @@ resource "random_pet" "this" {
 
 module "naming" {
   source = "Azure/naming/azurerm"
-  suffix = [ random_pet.this.id ]
+  suffix = [random_pet.this.id]
 }
 
 module "alz_management_resources" {

--- a/examples/alzreference/main.tf
+++ b/examples/alzreference/main.tf
@@ -5,16 +5,17 @@ resource "random_pet" "this" {
 
 module "naming" {
   source = "Azure/naming/azurerm"
+  suffix = [ random_pet.this.id ]
 }
 
 module "alz_management_resources" {
   source  = "Azure/alz-management/azurerm"
   version = "~> 0.1.0"
 
-  automation_account_name      = module.naming.automation_account.name_unique
+  automation_account_name      = module.naming.automation_account.name
   location                     = local.default_location
-  log_analytics_workspace_name = module.naming.log_analytics_workspace.name_unique
-  resource_group_name          = module.naming.resource_group.name_unique
+  log_analytics_workspace_name = module.naming.log_analytics_workspace.name
+  resource_group_name          = module.naming.resource_group.name
 }
 
 # This allows us to get the tenant id
@@ -77,8 +78,8 @@ module "alz_archetype_connectivity" {
 
 module "alz_archetype_management" {
   source                             = "../../"
-  id                                 = "management"
-  display_name                       = "management"
+  id                                 = "${random_pet.this.id}-management"
+  display_name                       = "${random_pet.this.id}-management"
   parent_id                          = module.alz_archetype_platform.management_group_name
   base_archetype                     = "management"
   default_location                   = local.default_location

--- a/examples/alzreference/main.tf
+++ b/examples/alzreference/main.tf
@@ -5,7 +5,7 @@ resource "random_pet" "this" {
 
 module "naming" {
   source = "Azure/naming/azurerm"
-  suffix = [ random_pet.this.id ]
+  suffix = [random_pet.this.id]
 }
 
 module "alz_management_resources" {

--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ resource "azurerm_management_group_policy_assignment" "this" {
   metadata             = jsonencode(try(each.value.properties.metadata, {}))
   parameters           = try(each.value.properties.parameters, null) != null && try(each.value.properties.parameters, {}) != {} ? jsonencode(each.value.properties.parameters) : null
   location             = try(each.value.location, null)
+  not_scopes           = try(each.value.properties.notScopes, [])
 
   depends_on = [time_sleep.before_policy_assignments]
 


### PR DESCRIPTION
This PR adds some consistent naming to the example to make it easier to find the resource group and to remove a potential conflict with the `management` resource group.

It also adds the missing `not_scopes` variable as this was causing unnecessary plan changes on a re-plan.