### PR TITLE
feature: add subscription placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following resources are used by this module:
 - [alz_policy_role_assignments.this](https://registry.terraform.io/providers/azure/alz/latest/docs/resources/policy_role_assignments) (resource)
 - [azurerm_management_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group) (resource)
 - [azurerm_management_group_policy_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_policy_assignment) (resource)
+- [azurerm_management_group_subscription_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) (resource)
 - [azurerm_policy_definition.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_definition) (resource)
 - [azurerm_policy_set_definition.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_set_definition) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
@@ -45,6 +46,7 @@ The following resources are used by this module:
 - [time_sleep.before_policy_role_assignments](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [alz_archetype.this](https://registry.terraform.io/providers/azure/alz/latest/docs/data-sources/archetype) (data source)
 - [alz_archetype_keys.this](https://registry.terraform.io/providers/azure/alz/latest/docs/data-sources/archetype_keys) (data source)
+- [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -200,6 +202,14 @@ Default: `[]`
 ### <a name="input_role_definitions_to_remove"></a> [role\_definitions\_to\_remove](#input\_role\_definitions\_to\_remove)
 
 Description: A set of role definition names to remove from the `base_archetype`.
+
+Type: `set(string)`
+
+Default: `[]`
+
+### <a name="input_subscription_ids"></a> [subscription\_ids](#input\_subscription\_ids)
+
+Description: A set of subscription ids to move under this management group.
 
 Type: `set(string)`
 

--- a/examples/alzreference/README.md
+++ b/examples/alzreference/README.md
@@ -91,6 +91,7 @@ module "alz_archetype_management" {
   base_archetype                     = "management"
   default_location                   = local.default_location
   default_log_analytics_workspace_id = module.alz_management_resources.log_analytics_workspace.id
+  subscription_ids                   = [data.azurerm_client_config.current.subscription_id]
 }
 
 module "alz_archetype_corp" {

--- a/examples/alzreference/main.tf
+++ b/examples/alzreference/main.tf
@@ -84,6 +84,7 @@ module "alz_archetype_management" {
   base_archetype                     = "management"
   default_location                   = local.default_location
   default_log_analytics_workspace_id = module.alz_management_resources.log_analytics_workspace.id
+  subscription_ids                   = [data.azurerm_client_config.current.subscription_id]
 }
 
 module "alz_archetype_corp" {

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,17 @@ resource "azurerm_management_group" "this" {
   depends_on = [time_sleep.before_management_group_creation]
 }
 
+data "azurerm_subscription" "this" {
+  for_each        = var.subscription_ids
+  subscription_id = each.key
+}
+
+resource "azurerm_management_group_subscription_association" "this" {
+  for_each            = var.subscription_ids
+  management_group_id = azurerm_management_group.this.id
+  subscription_id     = data.azurerm_subscription.this[each.key].id
+}
+
 resource "azurerm_policy_definition" "this" {
   for_each = local.alz_policy_definitions_decoded
 

--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "azurerm_management_group_policy_assignment" "this" {
 
     content {
       type         = identity.value.type
-      identity_ids = identity.value.type == "SystemAssigned" ? null : toset(keys(identity.value.userAssignedIdentities))
+      identity_ids = identity.value.type == "SystemAssigned" ? [] : toset(keys(identity.value.userAssignedIdentities))
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,14 @@ A set of role definition names to remove from the `base_archetype`.
 DESCRIPTION
 }
 
+variable "subscription_ids" {
+  type        = set(string)
+  default     = []
+  description = <<DESCRIPTION
+A set of subscription ids to move under this management group.
+DESCRIPTION
+}
+
 variable "delays" {
   type = object({
     before_management_group = optional(object({


### PR DESCRIPTION
This PR is to extend the module with a subscription placement capability for those not using Subscription vending for this.

This update uses a data source to validate the subscription exists and that the account has access to it.

More details in issue #16 

Test results:
![image](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/assets/1612200/a3ed7334-d54e-4865-a631-ed5d1fd1e283)
