### PR TITLE
bug: fix non-compliance message enforcement mode

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -17,3 +17,6 @@ locals {
     }
   } : {}
 }
+
+//Non-compliance message constants
+

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "azurerm_management_group_policy_assignment" "this" {
     for_each = try(each.value.properties.nonComplianceMessages, [])
 
     content {
-      content                        = non_compliance_message.value.message
+      content                        = replace(lookup(non_compliance_message.value, "message", var.policy_non_compliance_message_default), var.policy_non_compliance_message_enforcement_placeholder, try(each.value.properties.enforce, "Default") == "Default" ? var.policy_non_compliance_message_enforced_replacement : var.policy_non_compliance_message_not_enforced_replacement)
       policy_definition_reference_id = try(non_compliance_message.value.policyDefinitionReferenceId, null)
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,51 @@ A map of delays to apply to the creation and destruction of resources.
 Included to work around some race conditions in Azure.
 DESCRIPTION
 }
+
+variable "policy_non_compliance_message_default" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the default non-compliance message used for policy assignments."
+DESCRIPTION
+  default     = "This resource {enforcementMode} be compliant with the assigned policy."
+  validation {
+    condition     = var.policy_non_compliance_message_default != null && length(var.policy_non_compliance_message_default) > 0
+    error_message = "The policy_non_compliance_message_default value must not be null or empty."
+  }
+}
+
+variable "policy_non_compliance_message_enforcement_placeholder" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the non-compliance message placeholder used in message templates.
+DESCRIPTION
+  default     = "{enforcementMode}"
+  validation {
+    condition     = var.policy_non_compliance_message_enforcement_placeholder != null && length(var.policy_non_compliance_message_enforcement_placeholder) > 0
+    error_message = "The policy_non_compliance_message_enforcement_placeholder value must not be null or empty."
+  }
+}
+
+variable "policy_non_compliance_message_enforced_replacement" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the non-compliance replacement used for enforced policy assignments.
+DESCRIPTION
+  default     = "must"
+  validation {
+    condition     = var.policy_non_compliance_message_enforced_replacement != null && length(var.policy_non_compliance_message_enforced_replacement) > 0
+    error_message = "The policy_non_compliance_message_enforced_replacement value must not be null or empty."
+  }
+}
+
+variable "policy_non_compliance_message_not_enforced_replacement" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the non-compliance replacement used for unenforced policy assignments.
+DESCRIPTION
+  default     = "should"
+  validation {
+    condition     = var.policy_non_compliance_message_not_enforced_replacement != null && length(var.policy_non_compliance_message_not_enforced_replacement) > 0
+    error_message = "The policy_non_compliance_message_not_enforced_replacement value must not be null or empty."
+  }
+}


### PR DESCRIPTION
The enforcement mode replacement was not being set. This adds the relevant varialbes for users to override the behaviour and localisation and adds the replacement logic.