### PR TITLE
feat: non compliance message enforcement mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,38 @@ Type: `set(string)`
 
 Default: `[]`
 
+### <a name="input_policy_non_compliance_message_default"></a> [policy\_non\_compliance\_message\_default](#input\_policy\_non\_compliance\_message\_default)
+
+Description: If set overrides the default non-compliance message used for policy assignments."
+
+Type: `string`
+
+Default: `"This resource {enforcementMode} be compliant with the assigned policy."`
+
+### <a name="input_policy_non_compliance_message_enforced_replacement"></a> [policy\_non\_compliance\_message\_enforced\_replacement](#input\_policy\_non\_compliance\_message\_enforced\_replacement)
+
+Description: If set overrides the non-compliance replacement used for enforced policy assignments.
+
+Type: `string`
+
+Default: `"must"`
+
+### <a name="input_policy_non_compliance_message_enforcement_placeholder"></a> [policy\_non\_compliance\_message\_enforcement\_placeholder](#input\_policy\_non\_compliance\_message\_enforcement\_placeholder)
+
+Description: If set overrides the non-compliance message placeholder used in message templates.
+
+Type: `string`
+
+Default: `"{enforcementMode}"`
+
+### <a name="input_policy_non_compliance_message_not_enforced_replacement"></a> [policy\_non\_compliance\_message\_not\_enforced\_replacement](#input\_policy\_non\_compliance\_message\_not\_enforced\_replacement)
+
+Description: If set overrides the non-compliance replacement used for unenforced policy assignments.
+
+Type: `string`
+
+Default: `"should"`
+
 ### <a name="input_policy_set_definitions_to_add"></a> [policy\_set\_definitions\_to\_add](#input\_policy\_set\_definitions\_to\_add)
 
 Description: A set of policy set definition names to add to the `base_archetype`.  

--- a/locals.tf
+++ b/locals.tf
@@ -17,3 +17,6 @@ locals {
     }
   } : {}
 }
+
+//Non-compliance message constants
+

--- a/locals.tf
+++ b/locals.tf
@@ -19,4 +19,9 @@ locals {
 }
 
 //Non-compliance message constants
+locals {
+  policy_set_mode                               = "PolicySet"
+  non_compliance_message_supported_policy_modes = ["All", "Indexed", local.policy_set_mode]
+}
+
 

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "azurerm_management_group_policy_assignment" "this" {
     for_each = try(each.value.properties.nonComplianceMessages, [])
 
     content {
-      content                        = non_compliance_message.value.message
+      content                        = replace(lookup(non_compliance_message.value, "message", var.policy_non_compliance_message_default), var.policy_non_compliance_message_enforcement_placeholder, try(each.value.properties.enforce, "Default") == "Default" ? var.policy_non_compliance_message_enforced_replacement : var.policy_non_compliance_message_not_enforced_replacement)
       policy_definition_reference_id = try(non_compliance_message.value.policyDefinitionReferenceId, null)
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,51 @@ A map of delays to apply to the creation and destruction of resources.
 Included to work around some race conditions in Azure.
 DESCRIPTION
 }
+
+variable "policy_non_compliance_message_default" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the default non-compliance message used for policy assignments."
+DESCRIPTION
+  default     = "This resource {enforcementMode} be compliant with the assigned policy."
+  validation {
+    condition     = var.policy_non_compliance_message_default != null && length(var.policy_non_compliance_message_default) > 0
+    error_message = "The policy_non_compliance_message_default value must not be null or empty."
+  }
+}
+
+variable "policy_non_compliance_message_enforcement_placeholder" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the non-compliance message placeholder used in message templates.
+DESCRIPTION
+  default     = "{enforcementMode}"
+  validation {
+    condition     = var.policy_non_compliance_message_enforcement_placeholder != null && length(var.policy_non_compliance_message_enforcement_placeholder) > 0
+    error_message = "The policy_non_compliance_message_enforcement_placeholder value must not be null or empty."
+  }
+}
+
+variable "policy_non_compliance_message_enforced_replacement" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the non-compliance replacement used for enforced policy assignments.
+DESCRIPTION
+  default     = "must"
+  validation {
+    condition     = var.policy_non_compliance_message_enforced_replacement != null && length(var.policy_non_compliance_message_enforced_replacement) > 0
+    error_message = "The policy_non_compliance_message_enforced_replacement value must not be null or empty."
+  }
+}
+
+variable "policy_non_compliance_message_not_enforced_replacement" {
+  type        = string
+  description = <<DESCRIPTION
+If set overrides the non-compliance replacement used for unenforced policy assignments.
+DESCRIPTION
+  default     = "should"
+  validation {
+    condition     = var.policy_non_compliance_message_not_enforced_replacement != null && length(var.policy_non_compliance_message_not_enforced_replacement) > 0
+    error_message = "The policy_non_compliance_message_not_enforced_replacement value must not be null or empty."
+  }
+}


### PR DESCRIPTION
The enforcement mode replacement was not being set. This adds the relevant varialbes for users to override the behaviour and localisation and adds the replacement logic.

Prior to the change it looked like this:
![image](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/assets/1612200/3983e191-2354-490d-94f8-bafe43007066)

Now it looks like this:
![image](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/assets/1612200/d7221a7a-8bc7-4583-841d-5031af4e5e38)
