### PR TITLE
chore: Update Terraform required_version for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the release notes [here](https://github.com/hashicorp/terraform/releases/tag
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.8)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_alz"></a> [alz](#requirement\_alz) (~> 0.17)
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -20,7 +20,7 @@ module "alz_architecture" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.8)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_alz"></a> [alz](#requirement\_alz) (~> 0.17)
 

--- a/examples/default/terraform.tf
+++ b/examples/default/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     alz = {
       source  = "azure/alz"

--- a/examples/management/README.md
+++ b/examples/management/README.md
@@ -80,7 +80,7 @@ module "alz" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.8)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_alz"></a> [alz](#requirement\_alz) (~> 0.16)
 

--- a/examples/management/terraform.tf
+++ b/examples/management/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     alz = {
       source  = "Azure/alz"

--- a/examples/policy-assignment-modification-with-custom-lib/README.md
+++ b/examples/policy-assignment-modification-with-custom-lib/README.md
@@ -86,7 +86,7 @@ module "alz" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.8)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_alz"></a> [alz](#requirement\_alz) (~> 0.16)
 

--- a/examples/policy-assignment-modification-with-custom-lib/terraform.tf
+++ b/examples/policy-assignment-modification-with-custom-lib/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     alz = {
       source  = "azure/alz"

--- a/examples/privatednszones/README.md
+++ b/examples/privatednszones/README.md
@@ -69,7 +69,7 @@ module "alz" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.8)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_alz"></a> [alz](#requirement\_alz) (~> 0.16)
 

--- a/examples/privatednszones/terraform.tf
+++ b/examples/privatednszones/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     alz = {
       source  = "Azure/alz"

--- a/examples/template-architecture-definition/README.md
+++ b/examples/template-architecture-definition/README.md
@@ -38,7 +38,7 @@ module "alz_architecture" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.8)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_alz"></a> [alz](#requirement\_alz) (~> 0.16)
 

--- a/examples/template-architecture-definition/terraform.tf
+++ b/examples/template-architecture-definition/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     alz = {
       source  = "azure/alz"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     alz = {
       source  = "azure/alz"


### PR DESCRIPTION
## Description

This PR updates the Terraform `required_version` constraint to ensure consistency across all AVM modules. The constraint has been set to `>= 1.9, < 2.0` to maintain compatibility and leverage the features available in Terraform versions within this range.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g., CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!-- Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
