### PR TITLE
fix: default mg name - fixes #181

### DIFF
--- a/main.hierarchy_settings.tf
+++ b/main.hierarchy_settings.tf
@@ -6,7 +6,7 @@ resource "azapi_resource" "hierarchy_settings" {
   type = "Microsoft.Management/managementGroups/settings@2023-04-01"
   body = {
     properties = {
-      defaultManagementGroup               = var.management_group_hierarchy_settings.default_management_group_name
+      defaultManagementGroup               = provider::azapi::tenant_resource_id("Microsoft.Management/managementGroups", [var.management_group_hierarchy_settings.default_management_group_name])
       requireAuthorizationForGroupCreation = var.management_group_hierarchy_settings.require_authorization_for_group_creation
     }
   }
@@ -27,7 +27,7 @@ resource "azapi_update_resource" "hierarchy_settings" {
   type = "Microsoft.Management/managementGroups/settings@2023-04-01"
   body = {
     properties = {
-      defaultManagementGroup               = var.management_group_hierarchy_settings.default_management_group_name
+      defaultManagementGroup               = provider::azapi::tenant_resource_id("Microsoft.Management/managementGroups", [var.management_group_hierarchy_settings.default_management_group_name])
       requireAuthorizationForGroupCreation = var.management_group_hierarchy_settings.require_authorization_for_group_creation
     }
   }

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -2,10 +2,6 @@ data "azapi_client_config" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 }
 
-data "alz_metadata" "telemetry" {
-  count = var.enable_telemetry ? 1 : 0
-}
-
 data "modtm_module_source" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 

--- a/main.telemetry_custom.tf
+++ b/main.telemetry_custom.tf
@@ -1,0 +1,6 @@
+# Using a seperate file to allow use of _override file for main telemetry,
+# this way it isn't overwritten by repo goverenance.
+
+data "alz_metadata" "telemetry" {
+  count = var.enable_telemetry ? 1 : 0
+}

--- a/main.telemetry_override.tf
+++ b/main.telemetry_override.tf
@@ -2,10 +2,6 @@ data "azapi_client_config" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 }
 
-data "alz_metadata" "telemetry" {
-  count = var.enable_telemetry ? 1 : 0
-}
-
 data "modtm_module_source" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 

--- a/tests/unit/hierarchysettings.tftest.hcl
+++ b/tests/unit/hierarchysettings.tftest.hcl
@@ -40,7 +40,7 @@ run "creation" {
   }
 
   assert {
-    condition     = azapi_resource.hierarchy_settings[0].body.properties.defaultManagementGroup == "test"
+    condition     = azapi_resource.hierarchy_settings[0].body.properties.defaultManagementGroup == "/providers/Microsoft.Management/managementGroups/test"
     error_message = "The default management group is not correct."
   }
 
@@ -67,7 +67,7 @@ run "update" {
   }
 
   assert {
-    condition     = azapi_update_resource.hierarchy_settings[0].body.properties.defaultManagementGroup == "test"
+    condition     = azapi_update_resource.hierarchy_settings[0].body.properties.defaultManagementGroup == "/providers/Microsoft.Management/managementGroups/test"
     error_message = "The default management group is not correct."
   }
 
@@ -75,4 +75,68 @@ run "update" {
     condition     = length(azapi_update_resource.hierarchy_settings) == 1
     error_message = "The hierarchy settings update resource should be created."
   }
+}
+
+run "mg_name" {
+  command = plan
+
+  variables {
+    management_group_hierarchy_settings = {
+      default_management_group_name            = "test-123-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaavsdavavavavavavavvaavvavavavva-TEST-()_.zzz"
+      require_authorization_for_group_creation = true
+      update_existing                          = false
+    }
+  }
+
+  assert {
+    condition     = length(azapi_resource.hierarchy_settings) == 1
+    error_message = "The hierarchy settings resource should be created."
+  }
+
+  assert {
+    condition     = azapi_resource.hierarchy_settings[0].body.properties.defaultManagementGroup == "/providers/Microsoft.Management/managementGroups/test-123-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaavsdavavavavavavavvaavvavavavva-TEST-()_.zzz"
+    error_message = "The default management group is not correct."
+  }
+}
+
+run "mg_name_invalid_end_with_period" {
+  command = plan
+
+  variables {
+    management_group_hierarchy_settings = {
+      default_management_group_name            = "test."
+      require_authorization_for_group_creation = true
+      update_existing                          = false
+    }
+  }
+
+  expect_failures = [var.management_group_hierarchy_settings]
+}
+
+run "mg_name_invalid_chars" {
+  command = plan
+
+  variables {
+    management_group_hierarchy_settings = {
+      default_management_group_name            = "tes$t"
+      require_authorization_for_group_creation = true
+      update_existing                          = false
+    }
+  }
+
+  expect_failures = [var.management_group_hierarchy_settings]
+}
+
+run "mg_name_too_long" {
+  command = plan
+
+  variables {
+    management_group_hierarchy_settings = {
+      default_management_group_name            = "test-123-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaavsdavavavavavavavvaavvavavavva-TEST-()_.zzzz"
+      require_authorization_for_group_creation = true
+      update_existing                          = false
+    }
+  }
+
+  expect_failures = [var.management_group_hierarchy_settings]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,17 +79,14 @@ DESCRIPTION
     condition     = var.management_group_hierarchy_settings == null ? true : var.management_group_hierarchy_settings.default_management_group_name != ""
     error_message = "The default management group name must not be an empty string."
   }
-
   validation {
     condition     = var.management_group_hierarchy_settings == null ? true : var.management_group_hierarchy_settings.default_management_group_name != null
     error_message = "The default management group name must not be null."
   }
-
   validation {
     condition     = var.management_group_hierarchy_settings == null ? true : can(regex("^[a-zA-Z0-9_.()\\-]{1,90}$", var.management_group_hierarchy_settings.default_management_group_name))
     error_message = "Mangement group name must be between 1-90 characters. It must start with a letter or a number, and consist only of alphanumerics, hyphens, underscores, periods, and parentheses."
   }
-
   validation {
     error_message = "The management group name must not end with a period."
     condition     = var.management_group_hierarchy_settings == null ? true : !can(regex("\\.$", var.management_group_hierarchy_settings.default_management_group_name))

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,26 @@ Set this value to configure the hierarchy settings. Options are:
 - `require_authorization_for_group_creation` - (Optional) By default, all Entra security principals can create new management groups. When enabled, security principals must have management group write access to create new management groups. Defaults to `true`.
 - `update_existing` - (Optional) Update existing hierarchy settings rather than create new. Defaults to `false`.
 DESCRIPTION
+
+  validation {
+    condition     = var.management_group_hierarchy_settings == null ? true : var.management_group_hierarchy_settings.default_management_group_name != ""
+    error_message = "The default management group name must not be an empty string."
+  }
+
+  validation {
+    condition     = var.management_group_hierarchy_settings == null ? true : var.management_group_hierarchy_settings.default_management_group_name != null
+    error_message = "The default management group name must not be null."
+  }
+
+  validation {
+    condition     = var.management_group_hierarchy_settings == null ? true : can(regex("^[a-zA-Z0-9_.()\\-]{1,90}$", var.management_group_hierarchy_settings.default_management_group_name))
+    error_message = "Mangement group name must be between 1-90 characters. It must start with a letter or a number, and consist only of alphanumerics, hyphens, underscores, periods, and parentheses."
+  }
+
+  validation {
+    error_message = "The management group name must not end with a period."
+    condition     = var.management_group_hierarchy_settings == null ? true : !can(regex("\\.$", var.management_group_hierarchy_settings.default_management_group_name))
+  }
 }
 
 variable "override_policy_definition_parameter_assign_permissions_set" {


### PR DESCRIPTION
Adds variable validation for hierarchy settings default mg name.

Uses azapi function to construct resource id of mg for the hierarchy settings body

fixes #181 
