### PR TITLE
fix: add filtering for private DNS zone policy role assignments

### DIFF
--- a/_header.md
+++ b/_header.md
@@ -49,6 +49,26 @@ This variable is used as a workaround for the lack of support for `depends_on` i
 Place values into this variable to ensure that policies and policy role assignments do not get created until dependent resources are available.
 See the variable documentation and the examples (private DNS and management) for more information.
 
+#### Private DNS Zone Policy Role Assignment Filtering
+
+When using the ALZ connectivity pattern module, you can control which private DNS zone policy role assignments are created by passing the connectivity module's DNS zone resource IDs through the dependencies variable:
+
+```terraform
+module "alz_identity" {
+  source = "Azure/avm-ptn-alz/azurerm"
+  # ... other configuration ...
+  
+  dependencies = {
+    policy_assignments = [
+      module.alz_connectivity.private_dns_zone_resource_ids,
+      # ... other dependencies
+    ]
+  }
+}
+```
+
+This ensures that policy role assignments are only created for DNS zones that actually exist in your connectivity module, preventing errors when trying to assign roles to non-existent resources.
+
 ### Using Provider Functions
 
 Either: Use known values as inputs, or use Terraform Stacks.


### PR DESCRIPTION
## Description
Fixes policy role assignment creation for private DNS zones by implementing content-aware filtering based on actual DNS zone resources.

Closes #244

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

