### PR TITLE
feat: add role_assignments_enabled toggle to policy_assignments_to_modify

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ The key of this map is the assignment name, and the value is an object with opti
     - `in` - (Optional) A set of strings to include in the selector.
     - `not_in` - (Optional) A set of strings to exclude from the selector.
 - `creation_enabled` - (Optional) Whether the policy assignment is created or not. Defaults to `true`. IMPORTANT: This is a convenience property for very small scale deployments, the recommended approach is to update your custom library to exclude the policy assignment.
+- `role_assignments_enabled` - (Optional) Whether the policy role assignments (the RBAC assignments granted to the policy assignment's managed identity for `DeployIfNotExists`/`Modify` effects) are created or not. Defaults to `true`. Set to `false` to keep the policy assignment and its managed identity while preventing this module from creating the associated role assignments - for example, to avoid duplicate role assignments (`RoleAssignmentExists`) when a shared identity is used by the same policy assignment across multiple management groups. IMPORTANT: This is a convenience property; the recommended approach for broad changes is to update your custom library.
 
 Type:
 
@@ -687,7 +688,8 @@ map(object({
           not_in = optional(set(string), null)
         })), [])
       })))
-      creation_enabled = optional(bool, true)
+      creation_enabled         = optional(bool, true)
+      role_assignments_enabled = optional(bool, true)
     }))
   }))
 ```

--- a/locals.tf
+++ b/locals.tf
@@ -66,7 +66,7 @@ locals {
       principal_id       = lookup(local.policy_assignment_identities, "${pra.management_group_id}/${pra.policy_assignment_name}", tostring(null))
       role_definition_id = startswith(lower(pra.scope), "/subscriptions") ? "/subscriptions/${split("/", pra.scope)[2]}${pra.role_definition_id}" : pra.role_definition_id
       scope              = pra.scope
-    } if !strcontains(pra.scope, "00000000-0000-0000-0000-000000000000") && try(var.policy_assignments_to_modify[pra.management_group_id].policy_assignments[pra.policy_assignment_name].creation_enabled, true)
+    } if !strcontains(pra.scope, "00000000-0000-0000-0000-000000000000") && try(var.policy_assignments_to_modify[pra.management_group_id].policy_assignments[pra.policy_assignment_name].creation_enabled, true) && try(var.policy_assignments_to_modify[pra.management_group_id].policy_assignments[pra.policy_assignment_name].role_assignments_enabled, true)
   } : {}
 }
 

--- a/tests/unit/policyroleassignmentsenabled.tftest.hcl
+++ b/tests/unit/policyroleassignmentsenabled.tftest.hcl
@@ -1,0 +1,71 @@
+# Regression test for issue #4226.
+#
+# Verifies that setting `role_assignments_enabled = false` on a policy
+# assignment removes ONLY its generated policy role assignment(s), while the
+# policy assignment itself and its managed identity are still created.
+#
+# Uses the real `alz` provider (so `data.alz_architecture.this.policy_role_assignments`
+# is computed from the library) with `azapi`/`modtm` mocked and `command = plan`,
+# so no Azure authentication is required. The instance count of
+# `azapi_resource.policy_role_assignments` reflects the real `for_each` over
+# `local.policy_role_assignments`, which is what the fix filters.
+#
+# The custom `Deploy-PRA-Test` assignment targets a self-contained
+# DeployIfNotExists policy definition that declares `roleDefinitionIds`, so the
+# alz provider generates a policy role assignment from library data alone (no
+# Azure lookups required).
+
+provider "alz" {
+  library_references = [{
+    custom_url = "./tests/unit/testdata/policyroleassignmentsenabled"
+  }]
+}
+
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+
+variables {
+  location           = "swedencentral"
+  architecture_name  = "custom"
+  parent_resource_id = "pratestroot"
+}
+
+run "baseline_role_assignment_created" {
+  command = plan
+
+  assert {
+    condition     = length(output.policy_role_assignment_resource_ids) > 0
+    error_message = "Baseline: at least one policy role assignment should be planned for the DeployIfNotExists assignment."
+  }
+
+  assert {
+    condition     = length(output.policy_assignment_resource_ids) == 1
+    error_message = "Baseline: the policy assignment should be planned."
+  }
+}
+
+run "role_assignments_disabled_removes_only_role_assignment" {
+  command = plan
+
+  variables {
+    policy_assignments_to_modify = {
+      pratest = {
+        policy_assignments = {
+          "Deploy-PRA-Test" = {
+            role_assignments_enabled = false
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = length(output.policy_role_assignment_resource_ids) == 0
+    error_message = "With role_assignments_enabled = false the policy role assignment must NOT be created."
+  }
+
+  assert {
+    condition     = length(output.policy_assignment_resource_ids) == 1
+    error_message = "The policy assignment itself must still be created when role_assignments_enabled = false."
+  }
+}

--- a/tests/unit/testdata/policyroleassignmentsenabled/custom.alz_architecture_definition.yaml
+++ b/tests/unit/testdata/policyroleassignmentsenabled/custom.alz_architecture_definition.yaml
@@ -1,0 +1,8 @@
+name: custom
+management_groups:
+  - archetypes:
+      - root-custom
+    display_name: ALZ root
+    exists: false
+    id: pratest
+    parent_id: null

--- a/tests/unit/testdata/policyroleassignmentsenabled/custom_root.alz_archetype_definition.yaml
+++ b/tests/unit/testdata/policyroleassignmentsenabled/custom_root.alz_archetype_definition.yaml
@@ -1,0 +1,6 @@
+---
+name: root-custom
+policy_assignments:
+  - "Deploy-PRA-Test"
+policy_definitions:
+  - "Deploy-PRA-Test-Def"

--- a/tests/unit/testdata/policyroleassignmentsenabled/pra-test-assignment.alz_policy_assignment.json
+++ b/tests/unit/testdata/policyroleassignmentsenabled/pra-test-assignment.alz_policy_assignment.json
@@ -1,0 +1,22 @@
+{
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2022-06-01",
+  "name": "Deploy-PRA-Test",
+  "location": "${default_location}",
+  "identity": {
+    "type": "SystemAssigned"
+  },
+  "properties": {
+    "displayName": "PRA test assignment",
+    "description": "Test assignment for issue 4226.",
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/Deploy-PRA-Test-Def",
+    "enforcementMode": "Default",
+    "parameters": {
+      "effect": {
+        "value": "DeployIfNotExists"
+      }
+    },
+    "scope": "/providers/Microsoft.Management/managementGroups/placeholder",
+    "notScopes": []
+  }
+}

--- a/tests/unit/testdata/policyroleassignmentsenabled/pra-test-def.alz_policy_definition.json
+++ b/tests/unit/testdata/policyroleassignmentsenabled/pra-test-def.alz_policy_definition.json
@@ -1,0 +1,61 @@
+{
+  "name": "Deploy-PRA-Test-Def",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "policyType": "Custom",
+    "mode": "All",
+    "displayName": "PRA test - DeployIfNotExists requiring a role assignment",
+    "description": "Test policy for issue 4226 that generates a policy role assignment.",
+    "metadata": {
+      "category": "Test",
+      "version": "1.0.0"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "equals": "Microsoft.Resources/subscriptions"
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Insights/diagnosticSettings",
+          "deploymentScope": "subscription",
+          "existenceScope": "subscription",
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+          ],
+          "existenceCondition": {
+            "field": "type",
+            "equals": "Microsoft.Insights/diagnosticSettings"
+          },
+          "deployment": {
+            "location": "northeurope",
+            "properties": {
+              "mode": "incremental",
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {},
+                "resources": []
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -419,7 +419,8 @@ variable "policy_assignments_to_modify" {
           not_in = optional(set(string), null)
         })), [])
       })))
-      creation_enabled = optional(bool, true)
+      creation_enabled         = optional(bool, true)
+      role_assignments_enabled = optional(bool, true)
     }))
   }))
   default     = {}
@@ -452,6 +453,7 @@ The key of this map is the assignment name, and the value is an object with opti
     - `in` - (Optional) A set of strings to include in the selector.
     - `not_in` - (Optional) A set of strings to exclude from the selector.
 - `creation_enabled` - (Optional) Whether the policy assignment is created or not. Defaults to `true`. IMPORTANT: This is a convenience property for very small scale deployments, the recommended approach is to update your custom library to exclude the policy assignment.
+- `role_assignments_enabled` - (Optional) Whether the policy role assignments (the RBAC assignments granted to the policy assignment's managed identity for `DeployIfNotExists`/`Modify` effects) are created or not. Defaults to `true`. Set to `false` to keep the policy assignment and its managed identity while preventing this module from creating the associated role assignments - for example, to avoid duplicate role assignments (`RoleAssignmentExists`) when a shared identity is used by the same policy assignment across multiple management groups. IMPORTANT: This is a convenience property; the recommended approach for broad changes is to update your custom library.
 
 DESCRIPTION
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `role_assignments_enabled` (default `true`) to each entry in `policy_assignments_to_modify[<mg>].policy_assignments[<name>]`.

When set to `false`, the module still creates the policy assignment **and its managed identity**, but skips the associated policy role assignments (the RBAC grants for `DeployIfNotExists` / `Modify` effects). This lets users prevent duplicate role assignments (`RoleAssignmentExists`, HTTP 409) when a shared identity / the same assignment is applied across multiple management groups, without dropping the assignment or its identity.

The default of `true` preserves existing behaviour, so the change is fully backward compatible.

Relates to Azure/Azure-Landing-Zones#4226.

## Changes

- **`variables.tf`** — added `role_assignments_enabled = optional(bool, true)` to the `policy_assignments_to_modify` object (next to `creation_enabled`) with a description entry.
- **`locals.tf`** — extended the `local.policy_role_assignments` filter so an assignment's role assignments are skipped when `role_assignments_enabled = false`.
- **`README.md`** — regenerated to match.
- **`tests/unit/policyroleassignmentsenabled.tftest.hcl`** (+ fixture under `tests/unit/testdata/policyroleassignmentsenabled/`) — new regression test.

## Testing

The new test uses the **real `alz` provider** (so `data.alz_architecture.this.policy_role_assignments` is computed), with `azapi`/`modtm` **mocked** and `command = plan` — it needs **no Azure authentication** and runs in the standard unit suite. The fixture is a self-contained `DeployIfNotExists` policy that produces one policy role assignment.

### Before / after proof

**Baseline (no override):** the fixture produces 1 policy role assignment.

**After (`role_assignments_enabled = false`):** the policy role assignment is gone, the policy assignment is retained.

```text
run "baseline_role_assignment_created"...                       pass   # policy_role_assignment_resource_ids > 0, policy_assignment_resource_ids == 1
run "role_assignments_disabled_removes_only_role_assignment"... pass   # policy_role_assignment_resource_ids == 0, policy_assignment_resource_ids == 1

Success! 2 passed, 0 failed.
```

Full unit suite: `Success! 18 passed, 0 failed`.

### Control (proves the change is what drives the behaviour)

With the new `role_assignments_enabled` clause temporarily removed from `locals.tf` (everything else identical), the same run fails — the role assignment is **not** removed:

```text
run "role_assignments_disabled_removes_only_role_assignment"... fail
  Error: Test assertion failed
    condition = length(output.policy_role_assignment_resource_ids) == 0
      Diff:
      --- actual
      +++ expected
      - 1
      + 0
    With role_assignments_enabled = false the policy role assignment must NOT be created.

Failure! 1 passed, 1 failed.
```

`terraform fmt -check -recursive` and `terraform validate` are clean.